### PR TITLE
Cleanup generated files

### DIFF
--- a/integration/fabric/atsa/chaincode/atsa_test.go
+++ b/integration/fabric/atsa/chaincode/atsa_test.go
@@ -46,6 +46,12 @@ var _ = Describe("EndToEnd", func() {
 			bob = chaincode.NewClient(ii.Client("bob"), ii.Identity("bob"))
 		})
 
+		AfterEach(func() {
+			if !CurrentSpecReport().Failed() {
+				ii.Cleanup()
+			}
+		})
+
 		It("succeeded", func() {
 			// Create an asset
 

--- a/integration/fabric/atsa/fsc/atsa_test.go
+++ b/integration/fabric/atsa/fsc/atsa_test.go
@@ -48,6 +48,12 @@ var _ = Describe("EndToEnd", func() {
 			bob = client.New(ii.Client("bob"), ii.Identity("bob"), approver)
 		})
 
+		AfterEach(func() {
+			if !CurrentSpecReport().Failed() {
+				ii.Cleanup()
+			}
+		})
+
 		It("succeeded", func() {
 			txID, err := issuer.Issue(&states.Asset{
 				ObjectType:        "coin",

--- a/integration/fabric/fpc/echo/echo_test.go
+++ b/integration/fabric/fpc/echo/echo_test.go
@@ -36,6 +36,12 @@ var _ = Describe("EndToEnd", func() {
 			ii.Start()
 		})
 
+		AfterEach(func() {
+			if !CurrentSpecReport().Failed() {
+				ii.Cleanup()
+			}
+		})
+
 		It("succeeded", func() {
 			provisionedEnclavesBoxed, err := ii.Client("alice").CallView(
 				"ListProvisionedEnclaves",

--- a/integration/fabric/iou/iou_test.go
+++ b/integration/fabric/iou/iou_test.go
@@ -32,7 +32,7 @@ var _ = Describe("EndToEnd", func() {
 		BeforeEach(func() {
 			var err error
 			// Create the integration ii
-			ii, err = integration.GenerateAt(StartPort(), "", true, iou.Topology()...)
+			ii, err = integration.Generate(StartPort(), true, iou.Topology()...)
 			Expect(err).NotTo(HaveOccurred())
 			// Start the integration ii
 			ii.Start()

--- a/integration/fabric/iou/iou_test.go
+++ b/integration/fabric/iou/iou_test.go
@@ -40,6 +40,12 @@ var _ = Describe("EndToEnd", func() {
 			time.Sleep(20 * time.Second)
 		})
 
+		AfterEach(func() {
+			if !CurrentSpecReport().Failed() {
+				ii.Cleanup()
+			}
+		})
+
 		It("succeeded", func() {
 			res, err := ii.Client("borrower").CallView(
 				"create", common.JSONMarshall(&views.Create{

--- a/integration/fabric/stoprestart/stoprestart_test.go
+++ b/integration/fabric/stoprestart/stoprestart_test.go
@@ -37,6 +37,9 @@ var _ = Describe("EndToEnd", func() {
 		AfterEach(func() {
 			// Stop the ii
 			ii.Stop()
+			if !CurrentSpecReport().Failed() {
+				ii.Cleanup()
+			}
 		})
 
 		It("stop and restart successfully", func() {

--- a/integration/fabric/twonets/twonets_test.go
+++ b/integration/fabric/twonets/twonets_test.go
@@ -35,6 +35,12 @@ var _ = Describe("EndToEnd", func() {
 			ii.Start()
 		})
 
+		AfterEach(func() {
+			if !CurrentSpecReport().Failed() {
+				ii.Cleanup()
+			}
+		})
+
 		It("succeeded", func() {
 			res, err := ii.Client("alice").CallView("ping", nil)
 			Expect(err).NotTo(HaveOccurred())

--- a/integration/fabric/weaver/relay/relay_test.go
+++ b/integration/fabric/weaver/relay/relay_test.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package relay_test
 
 import (
-	"os"
-
 	"github.com/hyperledger-labs/fabric-smart-client/integration"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/fabric/weaver/relay"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common"
@@ -26,12 +24,10 @@ var _ = Describe("EndToEnd", func() {
 
 	Describe("Two Fabric Networks with Weaver Relay Life Cycle", func() {
 
-		var testdataPath = "./testdata"
-
 		BeforeEach(func() {
 			var err error
 			// Create the integration ii
-			ii, err = integration.GenerateAt(StartPort(), testdataPath, false, relay.Topology()...)
+			ii, err = integration.Generate(StartPort(), false, relay.Topology()...)
 			Expect(err).NotTo(HaveOccurred())
 			// Start the integration ii
 			ii.Start()
@@ -41,11 +37,6 @@ var _ = Describe("EndToEnd", func() {
 			res, err := ii.Client("alice").CallView("init", nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(common.JSONUnmarshalString(res)).To(BeEquivalentTo("OK"))
-
-			// cleanup testdata when test succeeds.
-			// if the test fails, we keep the test data for reviewing what went wrong
-			err = os.RemoveAll(testdataPath)
-			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/integration/fabric/weaver/relay/relay_test.go
+++ b/integration/fabric/weaver/relay/relay_test.go
@@ -33,6 +33,12 @@ var _ = Describe("EndToEnd", func() {
 			ii.Start()
 		})
 
+		AfterEach(func() {
+			if !CurrentSpecReport().Failed() {
+				ii.Cleanup()
+			}
+		})
+
 		It("succeeded", func() {
 			res, err := ii.Client("alice").CallView("init", nil)
 			Expect(err).NotTo(HaveOccurred())

--- a/integration/fsc/pingpong/pingpong_test.go
+++ b/integration/fsc/pingpong/pingpong_test.go
@@ -106,7 +106,7 @@ var _ = Describe("EndToEnd", func() {
 		It("generate artifacts & successful pingpong", func() {
 			var err error
 			// Create the integration ii
-			ii, err = integration.Generate(StartPortWithGeneration(), true, pingpong.Topology()...)
+			ii, err = integration.GenerateAt(StartPortWithGeneration(), integration.TemporaryDir, true, pingpong.Topology()...)
 			Expect(err).NotTo(HaveOccurred())
 			// Start the integration ii
 			ii.Start()
@@ -122,7 +122,7 @@ var _ = Describe("EndToEnd", func() {
 		It("generate artifacts & successful pingpong with Admin", func() {
 			var err error
 			// Create the integration ii
-			ii, err = integration.Generate(StartPortWithAdmin(), true, pingpong.Topology()...)
+			ii, err = integration.GenerateAt(StartPortWithAdmin(), integration.TemporaryDir, true, pingpong.Topology()...)
 			Expect(err).NotTo(HaveOccurred())
 			// Start the integration ii
 			ii.Start()

--- a/integration/fsc/stoprestart/stoprestart_test.go
+++ b/integration/fsc/stoprestart/stoprestart_test.go
@@ -37,6 +37,9 @@ var _ = Describe("EndToEnd", func() {
 		AfterEach(func() {
 			// Stop the ii
 			ii.Stop()
+			if !CurrentSpecReport().Failed() {
+				ii.Cleanup()
+			}
 		})
 
 		It("stop and restart successfully", func() {

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -113,7 +113,7 @@ func GenerateAt(startPort int, path string, race bool, topologies ...api.Topolog
 		n.EnableRaceDetector()
 	}
 	n.Generate()
-	n.DeleteOnStop = true
+	n.DeleteOnStop = false
 
 	return n, nil
 }
@@ -194,9 +194,14 @@ func (i *Infrastructure) Stop() {
 	}
 	defer i.BuildServer.Shutdown()
 	if i.DeleteOnStop {
-		defer os.RemoveAll(i.TestDir)
+		defer i.Cleanup()
 	}
 	i.NWO.Stop()
+}
+
+func (i *Infrastructure) Cleanup() {
+	os.RemoveAll(i.TestDir)
+	i.NWO.Cleanup()
 }
 
 func (i *Infrastructure) Serve() error {

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -35,6 +35,9 @@ import (
 
 var logger = flogging.MustGetLogger("fsc.integration")
 
+const TemporaryDir = ""      // The files will be deleted after success/failure
+const TestDir = "./testdata" // The files will be deleted after only success and if DeleteOnStop = true
+
 type Configuration struct {
 	StartPort int
 }
@@ -98,7 +101,7 @@ func New(startPort int, path string, topologies ...api.Topology) (*Infrastructur
 }
 
 func Generate(startPort int, race bool, topologies ...api.Topology) (*Infrastructure, error) {
-	return GenerateAt(startPort, "", race, topologies...)
+	return GenerateAt(startPort, TestDir, race, topologies...)
 }
 
 func GenerateAt(startPort int, path string, race bool, topologies ...api.Topology) (*Infrastructure, error) {
@@ -110,6 +113,7 @@ func GenerateAt(startPort int, path string, race bool, topologies ...api.Topolog
 		n.EnableRaceDetector()
 	}
 	n.Generate()
+	n.DeleteOnStop = true
 
 	return n, nil
 }

--- a/integration/nwo/nwo.go
+++ b/integration/nwo/nwo.go
@@ -166,11 +166,15 @@ func (n *NWO) Stop() {
 		}
 	}
 
+	n.Cleanup()
+	logger.Infof("Stopping...done!")
+}
+
+func (n *NWO) Cleanup() {
 	logger.Infof("Cleanup...")
 	for _, platform := range n.Platforms {
 		platform.Cleanup()
 	}
-	logger.Infof("Stopping...done!")
 }
 
 func (n *NWO) StopFSCNode(id string) {

--- a/integration/orion/cars/cars_test.go
+++ b/integration/orion/cars/cars_test.go
@@ -28,7 +28,7 @@ var _ = Describe("EndToEnd", func() {
 		BeforeEach(func() {
 			var err error
 			// Create the integration ii
-			ii, err = integration.GenerateAt(StartPort(), "", false, cars.Topology()...)
+			ii, err = integration.Generate(StartPort(), false, cars.Topology()...)
 			Expect(err).NotTo(HaveOccurred())
 			// Start the integration ii
 			ii.Start()

--- a/integration/orion/cars/cars_test.go
+++ b/integration/orion/cars/cars_test.go
@@ -38,6 +38,9 @@ var _ = Describe("EndToEnd", func() {
 		AfterEach(func() {
 			// Stop the ii
 			ii.Stop()
+			if !CurrentSpecReport().Failed() {
+				ii.Cleanup()
+			}
 		})
 
 		It("car registry demo", func() {


### PR DESCRIPTION
Integration tests currently place generated data into temporary directories that get erased after success or failure. We want these directories to remain under the directory /testdata in case of failure, and cleaned up in case of success.

Also, /cmd folders need to be cleaned up if they contain generated data.

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>